### PR TITLE
refactor: abstract asset and remove siteId

### DIFF
--- a/RenewXControl.Console/Domain/Assets/Asset.cs
+++ b/RenewXControl.Console/Domain/Assets/Asset.cs
@@ -6,17 +6,9 @@ using System.Threading.Tasks;
 
 namespace RenewXControl.Console.Domain.Assets
 {
-    // It's good to mark your base classes with 'abstract' modifier so, these classes can not be initialized directly.
-    // We never use them as a stand-alone object in out logic. We just use them to share some functionalities.
-    // Base class for all assets
-    public class Asset
+    public abstract class Asset
     {
-        public Asset(int siteId)
-        {
-            SiteId=siteId;
-        }
         public int Id { get; set; }
-        public int SiteId { get; set; }
         public string Name { get; set; }
     }
 }

--- a/RenewXControl.Console/Domain/Assets/Battery.cs
+++ b/RenewXControl.Console/Domain/Assets/Battery.cs
@@ -5,10 +5,9 @@ namespace RenewXControl.Console.Domain.Assets
     public class Battery : Asset
     {
         private static int _id = 0;
-        public Battery(BatteryConfig batteryConfig, int siteId) : base(siteId)
+        public Battery(BatteryConfig batteryConfig) 
         {
             Id = ++_id;
-            SiteId = siteId;
             Name = $"Battery{Id}";
             Capacity = batteryConfig.Capacity;
             StateOfCharge = batteryConfig.StateOfCharge;

--- a/RenewXControl.Console/Domain/Assets/SolarPanel.cs
+++ b/RenewXControl.Console/Domain/Assets/SolarPanel.cs
@@ -5,10 +5,9 @@ namespace RenewXControl.Console.Domain.Assets
     public class SolarPanel : Asset
     {
         private static int _id = 0;
-        public SolarPanel(SolarPanelConfig solarConfig, int siteId) : base(siteId)
+        public SolarPanel(SolarPanelConfig solarConfig) 
         {
             Id = ++_id;
-            SiteId=siteId;
             Name = $"SP{Id}";
             Irradiance = solarConfig.Irradiance;
             ActivePower = solarConfig.ActivePower;

--- a/RenewXControl.Console/Domain/Assets/WindTurbine.cs
+++ b/RenewXControl.Console/Domain/Assets/WindTurbine.cs
@@ -5,10 +5,9 @@ namespace RenewXControl.Console.Domain.Assets
     public class WindTurbine : Asset
     {
         private static int _id=0;
-        public WindTurbine(WindTurbineConfig turbineConfig,int siteId) : base(siteId)
+        public WindTurbine(WindTurbineConfig turbineConfig) 
         {
             Id = ++_id;
-            SiteId=siteId;
             Name = $"WT{Id}";
             WindSpeed = turbineConfig.WindSpeed;
             ActivePower = turbineConfig.ActivePower;

--- a/RenewXControl.Console/Program.cs
+++ b/RenewXControl.Console/Program.cs
@@ -15,9 +15,9 @@ var batteryConfig = ConfigurationSetting.ReadConfig<BatteryConfig>(fileName: "Ba
 // Map binding to our entity
 var user = new User(userConfig);
 var site = new Site(siteConfig, user.Id);
-var windTurbine = new WindTurbine(windTurbineConfig, site.Id);
-var solarPanel = new SolarPanel(solarPanelConfig, site.Id);
-var battery = new Battery(batteryConfig, site.Id);
+var windTurbine = new WindTurbine(windTurbineConfig);
+var solarPanel = new SolarPanel(solarPanelConfig);
+var battery = new Battery(batteryConfig);
 
 // Add assets to the site
 site.AddAsset(windTurbine);


### PR DESCRIPTION
 Technical Concepts and Essential Points
1. Abstract Base Classes
- Asset should be abstract because it is never used directly.
- It represents shared functionality, not a real-world object.
- Benefit: Prevents accidental misuse and promotes clean inheritance.
2. One-Way Relationship (Site → Assets)
- Assets should not store a SiteId.
- Instead, Site contains a List<Asset> and owns the asset relationship.

Reason: Reduces duplication, improves consistency, makes it easy to transfer an ass